### PR TITLE
Move typescript to development dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,10 +24,10 @@
     "@types/jest": "^24.9.0",
     "@types/moo": "^0.5.1",
     "jest": "^24.9.0",
-    "ts-jest": "^24.3.0"
+    "ts-jest": "^24.3.0",
+    "typescript": "^3.7.5"
   },
   "dependencies": {
-    "moo": "^0.5.1",
-    "typescript": "^3.7.5"
+    "moo": "^0.5.1"
   }
 }


### PR DESCRIPTION
typescript is not a runtime dependency of this package. Moving it to the development dependencies reduces the amount of packages installed in a production environment.