### PR TITLE
fix: function for generating random numbers

### DIFF
--- a/src/util/random.ts
+++ b/src/util/random.ts
@@ -1,5 +1,5 @@
 function random(min: number, max: number): number {
-  return Math.floor(Math.random() * Math.floor(max - min)) + min;
+  return Math.floor(Math.random() * Math.floor(max - min + 1)) + min;
 }
 
 export default random;


### PR DESCRIPTION
For an `d2` I never got `2` as a result.