### PR TITLE
Add a fault-tolerant version of tokenize

### DIFF
--- a/src/createDiceRoller.ts
+++ b/src/createDiceRoller.ts
@@ -22,12 +22,16 @@ function createDiceRoller(
   configOverrides: Partial<RollConfigOptions> = {}
 ) {
   const rollConfig = getDefaultRollConfigOptions(configOverrides);
-  const tokenize = createTokenize(plugins, rollConfig);
+  const { tokenize, tokenizeFaultTolerant } = createTokenize(
+    plugins,
+    rollConfig
+  );
   const rollDice = createRollDice(plugins, rollConfig);
   const tallyRolls = createTallyRolls(plugins, rollConfig);
 
   return {
     tokenize,
+    tokenizeFaultTolerant,
     calculateFinalResult,
     rollDice,
     tallyRolls,

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,10 +15,12 @@ export type {
   OperatorToken,
   DiceRollToken,
   Token,
+  ErrorToken,
 } from './tokens';
 
 export const {
   tokenize,
+  tokenizeFaultTolerant,
   calculateFinalResult,
   rollDice,
   tallyRolls,

--- a/src/roll.ts
+++ b/src/roll.ts
@@ -2,7 +2,7 @@ import { RollResults } from './rules/types';
 import createRollDice from './rollDice';
 import createTallyRolls, { RollTotal } from './tallyRolls';
 import calculateFinalResult from './calculateFinalResult';
-import createTokenize from './tokenize';
+import createTokenize, { Tokenize } from './tokenize';
 import { Token } from './tokens';
 import { RollConfigOptions, getFinalRollConfig } from './util/rollConfig';
 
@@ -14,7 +14,7 @@ export interface RollInformation {
 }
 
 function createRoll(
-  tokenize: ReturnType<typeof createTokenize>,
+  tokenize: Tokenize,
   rollDice: ReturnType<typeof createRollDice>,
   tallyRolls: ReturnType<typeof createTallyRolls>,
   rollConfig: RollConfigOptions

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -34,6 +34,12 @@ export interface DiceRollToken<T = any> extends BaseToken {
   detail: T;
 }
 
+export interface ErrorToken {
+  type: 'error';
+  position: number;
+  content: string;
+}
+
 export type Token =
   | OpenParenToken
   | CloseParenToken
@@ -93,4 +99,10 @@ export const constantToken = (
   content,
   detailType: CONSTANT,
   detail: value,
+});
+
+export const errorToken = (position: number, content: string): ErrorToken => ({
+  type: 'error',
+  position,
+  content,
 });


### PR DESCRIPTION
For my purposes, I want to have the dice notation syntax-highlight on the fly. Previously, while the user is typing `1d6`, it looks something like this:

`1`: valid
`1d`: invalid
`1d6`: valid

But if we allow the lexer to return an error token instead of blowing up, we can get the desired behavior:

https://user-images.githubusercontent.com/25882770/116820762-9de3a600-ab44-11eb-8a77-01c988d0a775.mp4

I'm torn between having a separate "fault tolerant" version of `tokenize` and building this directly into the API for tokenize. Any thoughts on this @n1ru4l?